### PR TITLE
Change arbitrum endpoint to corresponding `erigon3-v1..`

### DIFF
--- a/webseed/arb-sepolia.toml
+++ b/webseed/arb-sepolia.toml
@@ -1,1 +1,1 @@
-"e3-v1-pub" = "v1:https://erigon31-v1-snapshots-arb-sepolia.erigon.network"
+"e3-v1-pub" = "v1:https://erigon3-v1-snapshots-arb-sepolia.erigon.network"


### PR DESCRIPTION
Upload was done to bucket `erigon3-v1-snapshots-arb-sepolia` but given webseed fails to start downloading: erigon31 was expected but it is empty. Changing this webseed endpoint allowing download